### PR TITLE
Add the IPA ca cert to domain configuration

### DIFF
--- a/rdo-kerberos-setup/vm-post-cloud-init-rdo.sh
+++ b/rdo-kerberos-setup/vm-post-cloud-init-rdo.sh
@@ -165,6 +165,7 @@ group_allow_delete=false
 user_enabled_attribute=nsAccountLock
 user_enabled_default=False
 user_enabled_invert=true
+tls_cacertfile=/etc/ipa/ca.crt
 
 [identity]
 driver = keystone.identity.backends.ldap.Identity


### PR DESCRIPTION
Explicitly set the CA certificate to use when connecting to the IPA
server's TLS.

Note: This is something i found by following the scripts by hand 
and it may be there was something I missed that set this up 
correctly.
